### PR TITLE
client: Strip leading and trailing path separators

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -357,7 +357,10 @@ impl FileInfo {
 
     /// Get the URL-encoded server path for a specific download.
     pub fn download_remote_path(&self, index: u32) -> String {
-        let path = format!("{}/{}", self.server_path, self.download_name(index));
+        // The server does not accept duplicate separators. The AU region has
+        // trailing separators, but the US region does not.
+        let directory = self.server_path.trim_matches('/');
+        let path = format!("{directory}/{}", self.download_name(index));
 
         match urlencoding::encode(&path) {
             Cow::Borrowed(_) => path,


### PR DESCRIPTION
The `/car/download/<code>` API responses from the Australia region seem to include both leading and trailing separators in the `filePath` field, at least for `2022_EV6_AU`. The actual download endpoint does not accept them though.