### PR TITLE
Show better error message when autodetected region has no data

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -6,13 +6,13 @@ use std::{
     io::{self, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use cap_std::fs::{Dir, Metadata, OpenOptions};
 use crc32fast::Hasher;
 use tokio::{
@@ -272,7 +272,7 @@ impl Downloader {
                         continue;
                     }
                     Err(e) => {
-                        return Err(e).with_context(|| format!("Failed to open directory: {name}"))
+                        return Err(e).with_context(|| format!("Failed to open directory: {name}"));
                     }
                 }
             } else {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -8,7 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use indicatif::{style::ProgressTracker, BinaryBytes, MultiProgress, ProgressState};
+use indicatif::{BinaryBytes, MultiProgress, ProgressState, style::ProgressTracker};
 use tracing_subscriber::fmt::MakeWriter;
 
 /// Type that receives progress values and buffers them to compute the average


### PR DESCRIPTION
The MapCare servers now return country-specific region codes for EU countries instead of just `EU`. However, downloads currently aren't published for these country codes. This commit updates the region autodetection logic to show a better error message than a generic missing field error.

Fixes: #13