### PR TITLE
ci.yml: Set RUSTDOCFLAGS to statically link doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       CARGO_TERM_COLOR: always
       # https://github.com/rust-lang/rust/issues/78210
       RUSTFLAGS: -C strip=symbols -C target-feature=+crt-static
+      # https://github.com/rust-lang/cargo/pull/15462
+      RUSTDOCFLAGS: -C target-feature=+crt-static
       TARGETS: ${{ join(matrix.artifact.targets, ' ') || matrix.artifact.name }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Prior to Rust 1.89, these tests were just skipped when cross-compiling. Now, they are actually compiled and ran. Unfortunately, doctests don't use the normal `RUSTFLAGS` environment variable, so we also need to set `RUSTDOCFLAGS` or else the resulting dynamically linked executable will fail to run on a non-Android host.

Upstream change: https://github.com/rust-lang/cargo/pull/15462