### PR TITLE
Add commandline option and behavior for when a model has variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Add `-n`/`--nudl` and `-v`/`--version` to `nudl download` to disambiguate models with multiple variants sharing the same model ID (e.g., HEV vs PHEV) ([PR #23])
+
 ### Version 0.1.8
 
 * Update dependencies ([PR #22])
@@ -65,7 +69,4 @@
 [PR #17]: https://github.com/chenxiaolong/nudl/pull/17
 [PR #19]: https://github.com/chenxiaolong/nudl/pull/19
 [PR #22]: https://github.com/chenxiaolong/nudl/pull/22
-### Version 0.1.9
-
-* Add `--fw-version` to `nudl download` to disambiguate models with multiple variants sharing the same model ID (e.g., HEV vs PHEV)
-* Error on ambiguous model selection without `--fw-version` and list the available firmware versions to choose from
+[PR #23]: https://github.com/chenxiaolong/nudl/pull/23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,7 @@
 [PR #17]: https://github.com/chenxiaolong/nudl/pull/17
 [PR #19]: https://github.com/chenxiaolong/nudl/pull/19
 [PR #22]: https://github.com/chenxiaolong/nudl/pull/22
+### Version 0.1.9
+
+* Add `--fw-version` to `nudl download` to disambiguate models with multiple variants sharing the same model ID (e.g., HEV vs PHEV)
+* Error on ambiguous model selection without `--fw-version` and list the available firmware versions to choose from

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ To download the latest firmware for a vehicle, run:
 nudl download -b <brand> -m <model> -o <output directory>
 ```
 
+If a model has multiple variants that share the same model ID (for example, HEV vs PHEV), `nudl download` will error and list the available firmware versions. Disambiguate by specifying the exact firmware version shown by `nudl list`:
+
+```
+nudl download -b <brand> -m <model> --fw-version <firmware version>
+```
+
 To download firmware for a specific region, pass in `-r <region>`. The default region is determined server-side, likely via GeoIP. The list of known regions are:
 
 * `BR` - Brazil

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ To download the latest firmware for a vehicle, run:
 nudl download -b <brand> -m <model> -o <output directory>
 ```
 
-If a model has multiple variants that share the same model ID (for example, HEV vs PHEV), `nudl download` will error and list the available firmware versions. Disambiguate by specifying the exact firmware version shown by `nudl list`:
+If a model has multiple variants that share the same model ID (for example, HEV vs PHEV), `nudl download` will error and list the available firmware versions. Disambiguate by specifying the model name or exact firmware version shown by `nudl list`:
 
 ```
-nudl download -b <brand> -m <model> --fw-version <firmware version>
+nudl download -b <brand> -m <model> -n <model name>
+# Or
+nudl download -b <brand> -m <model> -v <firmware version>
 ```
 
 To download firmware for a specific region, pass in `-r <region>`. The default region is determined server-side, likely via GeoIP. The list of known regions are:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,6 +117,13 @@ pub struct DownloadCli {
     #[arg(short, long)]
     pub model: String,
 
+    /// Firmware version to disambiguate model variants.
+    ///
+    /// Only needed when multiple variants share the same model ID. Use the
+    /// version string printed by `nudl list`.
+    #[arg(long = "fw-version")]
+    pub fw_version: Option<String>,
+
     /// Output directory.
     #[arg(short, long, value_parser, default_value = ".")]
     pub output: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod model;
 mod progress;
 
 use std::{
+    fmt::{self, Display, Write as _},
     io::{self, IsTerminal, Write},
     time::Duration,
 };
@@ -24,7 +25,7 @@ use tracing::debug;
 
 use crate::{
     cli::{Brand, Cli, Command, DownloadCli, ListCli, OutputFormat},
-    client::{AutodetectedRegion, NuClient, NuClientBuilder},
+    client::{AutodetectedRegion, CarInfo, NuClient, NuClientBuilder},
     download::{Downloader, ProgressMessage},
     progress::{ProgressSuspendingStderr, SpeedTracker},
 };
@@ -77,11 +78,42 @@ async fn list_subcommand(cli: &Cli, list_cli: &ListCli) -> Result<()> {
 
     match list_cli.output {
         OutputFormat::Text => {
+            const HEADING_MODEL: &str = "MODEL";
+            const HEADING_NAME: &str = "NAME";
+            const HEADING_VERSION: &str = "VERSION";
+
             let cars = client.get_cars(&region, &guid, brand).await?;
-            let max_len = cars.iter().map(|c| c.id.len()).max().unwrap_or_default();
+            let model_max_len = cars
+                .iter()
+                .map(|c| c.id.len())
+                .max()
+                .unwrap_or_default()
+                .max(HEADING_MODEL.len());
+            let name_max_len = cars
+                .iter()
+                .map(|c| c.name.len())
+                .max()
+                .unwrap_or_default()
+                .max(HEADING_NAME.len());
+
+            writeln!(
+                stdout,
+                "{HEADING_MODEL:model_width$} {HEADING_NAME:name_width$} {HEADING_VERSION}",
+                model_width = model_max_len,
+                name_width = name_max_len + 2,
+            )?;
 
             for car in cars {
-                writeln!(stdout, "{:width$} {}", car.id, car.version, width = max_len)?;
+                writeln!(
+                    stdout,
+                    "{:id_width$} \"{}\"{:name_padding$} {}",
+                    car.id,
+                    car.name,
+                    "",
+                    car.version,
+                    id_width = model_max_len,
+                    name_padding = name_max_len - car.name.len(),
+                )?;
             }
         }
         OutputFormat::Json => {
@@ -101,6 +133,57 @@ async fn list_subcommand(cli: &Cli, list_cli: &ListCli) -> Result<()> {
     Ok(())
 }
 
+fn join(into_iter: impl IntoIterator<Item = impl Display>, sep: &str) -> String {
+    use std::fmt::Write;
+
+    let mut result = String::new();
+
+    for (i, item) in into_iter.into_iter().enumerate() {
+        if i > 0 {
+            result.push_str(sep);
+        }
+
+        write!(result, "{item}").expect("Failed to allocate");
+    }
+
+    result
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Selector {
+    Model(String),
+    Name(String),
+    Version(String),
+}
+
+impl Selector {
+    fn all_for_car(car: &CarInfo) -> Vec<Selector> {
+        vec![
+            Self::Model(car.id.clone()),
+            Self::Name(car.name.clone()),
+            Self::Version(car.version.clone()),
+        ]
+    }
+
+    fn matches_car(&self, car: &CarInfo) -> bool {
+        match self {
+            Self::Model(m) => car.id == *m,
+            Self::Name(n) => car.name == *n,
+            Self::Version(v) => car.version == *v,
+        }
+    }
+}
+
+impl fmt::Display for Selector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Model(m) => write!(f, "-m {m}"),
+            Self::Name(n) => write!(f, "-n \"{n}\""),
+            Self::Version(v) => write!(f, "-v {v}"),
+        }
+    }
+}
+
 async fn download_subcommand(
     cli: &Cli,
     download_cli: &DownloadCli,
@@ -116,42 +199,53 @@ async fn download_subcommand(
     let cars = client
         .get_cars(&region, &guid, download_cli.family.brand.as_code_str())
         .await?;
-    let candidates: Vec<_> = cars.iter().filter(|c| c.id == download_cli.model).collect();
-    if candidates.is_empty() {
-        bail!("No firmware found for model: {}", download_cli.model);
-    }
+    let selectors = download_cli.selector.to_selectors();
+    let candidates: Vec<_> = cars
+        .iter()
+        .filter(|c| selectors.iter().all(|s| s.matches_car(c)))
+        .collect();
+    let car = if candidates.is_empty() {
+        let mut msg = format!(
+            "No firmware versions found matching selector: {}",
+            join(selectors.iter(), " "),
+        );
 
-    let car = if let Some(ref ver) = download_cli.fw_version {
-        match candidates.iter().find(|c| &c.version == ver) {
-            Some(c) => *c,
-            None => {
-                let available: Vec<&str> = candidates.iter().map(|c| c.version.as_str()).collect();
-                bail!(
-                    "No firmware found for model '{}' with version '{}'. Available versions: {}",
-                    download_cli.model,
-                    ver,
-                    available.join(", ")
-                );
+        for selector in &selectors {
+            let available: Vec<_> = cars.iter().filter(|c| selector.matches_car(c)).collect();
+            if !available.is_empty() {
+                writeln!(&mut msg, "\n\nAvailable options for just: {selector}")?;
+            }
+
+            for car in available {
+                let disambiguation = Selector::all_for_car(car)
+                    .into_iter()
+                    .filter(|s| s != selector);
+
+                write!(&mut msg, "\n  {}", join(disambiguation, " "))?;
             }
         }
+
+        bail!(msg);
+    } else if candidates.len() > 1 {
+        let mut msg = format!(
+            "Multiple firmware versions found matching selector: {}\n",
+            join(selectors.iter(), " "),
+        );
+        msg.push_str("To disambiguate, rerun with one of the following:\n");
+
+        for car in candidates {
+            let disambiguation = Selector::all_for_car(car)
+                .into_iter()
+                .filter(|s| !selectors.contains(s));
+
+            write!(&mut msg, "\n  {}", join(disambiguation, " "))?;
+        }
+
+        bail!(msg);
     } else {
-        if candidates.len() > 1 {
-            let available: Vec<&str> = candidates.iter().map(|c| c.version.as_str()).collect();
-
-            let mut msg = format!(
-                "Multiple firmware variants found for model '{}'.\nPlease specify --fw-version with one of the following:\n",
-                download_cli.model
-            );
-            for v in &available {
-                msg.push_str(v);
-                msg.push('\n');
-            }
-            msg.push('\n');
-
-            bail!(msg);
-        }
         candidates[0]
     };
+
     let firmware = client.get_firmware_info(&region, car).await?;
 
     println!("ID: {}", car.id);


### PR DESCRIPTION
Existing nudl downloads the first firmware it sees, which in my case was HEV when I needed PHEV firmware.

I picked `--fw_version` as a commandline option (only needed in this ambiguous case), but wasn't sure if the shortened version sohuld be `-f` or `-v`. I'm open to suggestions :D