### PR TITLE
client: Firmware versions for the same model ID are identical

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -196,7 +196,10 @@ impl Downloader {
             &mut result,
             "+|{}|{}|{}|{}|{}|1",
             firmware.update_version,
-            car.version,
+            // The official app always puts the first listed version number in
+            // this file. All output files are exactly identical regardless of
+            // which firmware version the user selects for the same model ID.
+            car.versions[0],
             car.brand(),
             car.id,
             car.mcode,


### PR DESCRIPTION
Previously, we downloaded the same files for every firmware version, but the `.ver` file listed the requested firmware version. However, the official downloader app doesn't behave this way. It always lists the first firmware version in the file. This commit updates nudl to behave the same.

Issue: #24