### PR TITLE
Use unicode width when aligning columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "unicode-width",
  "urlencoding",
  "zipunsplitlib",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 tokio-stream = "0.1.14"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
+unicode-width = "0.2.1"
 urlencoding = "2.1.3"
 zipunsplitlib = { git = "https://github.com/chenxiaolong/zipunsplit.git", tag = "v0.1.1" }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 use tokio::signal::ctrl_c;
 use tracing::debug;
+use unicode_width::UnicodeWidthStr;
 
 use crate::{
     cli::{Brand, Cli, Command, DownloadCli, ListCli, OutputFormat},
@@ -83,24 +84,24 @@ async fn list_subcommand(cli: &Cli, list_cli: &ListCli) -> Result<()> {
             const HEADING_VERSION: &str = "VERSION";
 
             let cars = client.get_cars(&region, &guid, brand).await?;
-            let model_max_len = cars
+            let model_max_width = cars
                 .iter()
-                .map(|c| c.id.len())
+                .map(|c| c.id.width())
                 .max()
                 .unwrap_or_default()
-                .max(HEADING_MODEL.len());
-            let name_max_len = cars
+                .max(HEADING_MODEL.width());
+            let name_max_width = cars
                 .iter()
-                .map(|c| c.name.len())
+                .map(|c| c.name.width())
                 .max()
                 .unwrap_or_default()
-                .max(HEADING_NAME.len());
+                .max(HEADING_NAME.width());
 
             writeln!(
                 stdout,
                 "{HEADING_MODEL:model_width$} {HEADING_NAME:name_width$} {HEADING_VERSION}",
-                model_width = model_max_len,
-                name_width = name_max_len + 2,
+                model_width = model_max_width,
+                name_width = name_max_width + 2,
             )?;
 
             for car in cars {
@@ -111,8 +112,8 @@ async fn list_subcommand(cli: &Cli, list_cli: &ListCli) -> Result<()> {
                         car.id,
                         car.name,
                         "",
-                        id_width = model_max_len,
-                        name_padding = name_max_len - car.name.len(),
+                        id_width = model_max_width,
+                        name_padding = name_max_width - car.name.width(),
                     )?;
                 }
             }


### PR DESCRIPTION
Fixes severely misaligned text when running `nudl list -r KR`, which includes model names written in Korean.