### PR TITLE
Verify subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Unreleased
 
+* Add `nudl verify` command to check an already-downloaded firmware directory against its `.ver` checksums (eg. to validate a copy on a USB drive or SD card)
 * Update dependencies ([PR #56])
 
 ### Version 0.1.20

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Note that the progress bars may sometimes be misleading (eg. `32.73 GiB / 10.60 
 
 For more information about other command-line arguments, see `--help`.
 
+## Verifying an existing download
+
+When firmware is downloaded, nudl writes a `<model ID>.ver` file alongside it containing the expected CRC32 and size of every file. To re-verify an already-downloaded directory against that file — for example, to confirm that a copy onto a USB drive or SD card is intact — run:
+
+```
+nudl verify <directory>
+```
+
+This requires no network connection. Each file is reported as `OK`, `MISSING`, `BAD SIZE`, or `BAD CRC`, and the command exits with a non-zero status if any file fails. If the directory contains more than one `.ver` file, select one explicitly with `--ver-file <path>`.
+
 ## Building from source
 
 To build from source, first make sure that the Rust toolchain is installed. It can be installed from https://rustup.rs/ or the OS's package manager.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -176,10 +176,30 @@ pub struct DownloadCli {
     pub keep_raw: bool,
 }
 
+/// Verify an already-downloaded firmware directory.
+///
+/// The CRC32 and size of each file are checked against the `.ver` file that was
+/// written alongside the firmware when it was downloaded. This is useful for
+/// confirming that a copy (eg. to a USB drive or SD card) is intact. No network
+/// connection is required.
+#[derive(Debug, Parser)]
+pub struct VerifyCli {
+    /// Directory containing the downloaded firmware.
+    #[arg(value_parser, default_value = ".")]
+    pub directory: PathBuf,
+
+    /// Path to the `.ver` checksum file.
+    ///
+    /// If unspecified, the single `.ver` file in the directory is used.
+    #[arg(long, value_parser)]
+    pub ver_file: Option<PathBuf>,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Command {
     List(ListCli),
     Download(DownloadCli),
+    Verify(VerifyCli),
 }
 
 #[derive(Debug, Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod crypto;
 mod download;
 mod model;
 mod progress;
+mod verify;
 
 use std::{
     fmt::{self, Display, Write as _},
@@ -25,10 +26,11 @@ use tracing::debug;
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
-    cli::{Brand, Cli, Command, DownloadCli, ListCli, OutputFormat},
+    cli::{Brand, Cli, Command, DownloadCli, ListCli, OutputFormat, VerifyCli},
     client::{CarInfo, NuClient, NuClientBuilder},
     download::{Downloader, ProgressMessage},
     progress::{ProgressSuspendingStderr, SpeedTracker},
+    verify::FileStatus,
 };
 
 const PROGRESS_SPEED_WINDOW: Duration = Duration::from_secs(1);
@@ -353,6 +355,82 @@ async fn download_subcommand(
     Ok(())
 }
 
+fn verify_subcommand(verify_cli: &VerifyCli, bars: MultiProgress) -> Result<()> {
+    let authority = ambient_authority();
+    let directory = Dir::open_ambient_dir(&verify_cli.directory, authority)
+        .with_context(|| format!("Failed to open directory: {:?}", verify_cli.directory))?;
+
+    let ver_contents = match &verify_cli.ver_file {
+        Some(path) => std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read .ver file: {path:?}"))?,
+        None => {
+            let name = verify::find_ver_file(&directory)?;
+            directory
+                .read_to_string(&name)
+                .with_context(|| format!("Failed to read .ver file: {name}"))?
+        }
+    };
+
+    let entries = verify::parse_ver_file(&ver_contents)?;
+
+    // Total up the bytes of the files that actually exist so the progress bar
+    // reflects the work that can be done.
+    let mut total = 0;
+    for entry in &entries {
+        if let Ok(metadata) = directory.metadata(&entry.path) {
+            total += metadata.len();
+        }
+    }
+
+    let progress = bars.add(ProgressBar::hidden());
+    progress.set_prefix("Verify");
+    progress.set_style(progress_style());
+    progress.set_length(total);
+
+    let mut failures = 0;
+
+    for entry in &entries {
+        let status = verify::verify_entry(&directory, entry, |n| progress.inc(n))?;
+
+        let line = match status {
+            FileStatus::Ok => format!("OK       {}", entry.path),
+            FileStatus::Missing => {
+                failures += 1;
+                format!("MISSING  {}", entry.path)
+            }
+            FileStatus::SizeMismatch { expected, actual } => {
+                failures += 1;
+                format!(
+                    "BAD SIZE {} (expected {expected} bytes, got {actual})",
+                    entry.path,
+                )
+            }
+            FileStatus::CrcMismatch { expected, actual } => {
+                failures += 1;
+                format!(
+                    "BAD CRC  {} (expected {expected:08X}, got {actual:08X})",
+                    entry.path,
+                )
+            }
+        };
+
+        // Print to stdout (suspending the progress bar so it isn't clobbered in
+        // a terminal). Unlike `MultiProgress::println`, this is also visible
+        // when stdout is redirected to a file.
+        bars.suspend(|| println!("{line}"));
+    }
+
+    progress.finish_and_clear();
+
+    let total_files = entries.len();
+    if failures == 0 {
+        println!("All {total_files} files verified successfully");
+        Ok(())
+    } else {
+        bail!("{failures} of {total_files} files failed verification");
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -374,5 +452,6 @@ async fn main() -> Result<()> {
     match &cli.command {
         Command::List(c) => list_subcommand(&cli, c).await,
         Command::Download(c) => download_subcommand(&cli, c, bars).await,
+        Command::Verify(c) => verify_subcommand(c, bars),
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{
+    io::{self, Read},
+    path::Path,
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use cap_std::fs::Dir;
+use crc32fast::Hasher;
+
+/// A single file entry parsed from a `.ver` checksum file.
+#[derive(Clone, Debug)]
+pub struct VerEntry {
+    /// Path of the output file relative to the firmware directory.
+    pub path: String,
+    /// Expected CRC32 digest of the output file.
+    pub crc32: u32,
+    /// Expected size of the output file in bytes.
+    pub size: u64,
+}
+
+/// Result of verifying a single file against its expected checksum.
+#[derive(Debug)]
+pub enum FileStatus {
+    /// The file exists and its size and CRC32 both match.
+    Ok,
+    /// The file does not exist.
+    Missing,
+    /// The file exists but has a different size.
+    SizeMismatch { expected: u64, actual: u64 },
+    /// The file exists and has the expected size, but a different CRC32.
+    CrcMismatch { expected: u32, actual: u32 },
+}
+
+/// Parse the contents of a `.ver` checksum file.
+///
+/// The file has one header line beginning with `+`, followed by one line per
+/// file of the form:
+///
+/// ```text
+/// <model id>\<dir>|<name>|<version>|<crc32>|<size>|1
+/// ```
+///
+/// The `<crc32>` field is a signed 32-bit integer and the leading `<model id>`
+/// path component is not a real directory on disk (the official client and this
+/// tool both place files directly in the output directory), so it is stripped
+/// to produce a path relative to the firmware directory.
+pub fn parse_ver_file(contents: &str) -> Result<Vec<VerEntry>> {
+    let mut entries = Vec::new();
+
+    for (i, line) in contents.lines().enumerate() {
+        // Skip empty lines and the header line.
+        if line.is_empty() || line.starts_with('+') {
+            continue;
+        }
+
+        let fields: Vec<&str> = line.split('|').collect();
+        if fields.len() < 6 {
+            bail!("Malformed entry on line {}: {line:?}", i + 1);
+        }
+
+        let dir_field = fields[0];
+        let name = fields[1];
+        // Stored as a signed 32-bit integer, matching the server's raw value.
+        let crc32 = fields[3]
+            .parse::<i32>()
+            .with_context(|| format!("Invalid CRC32 on line {}: {:?}", i + 1, fields[3]))?
+            as u32;
+        let size = fields[4]
+            .parse::<u64>()
+            .with_context(|| format!("Invalid size on line {}: {:?}", i + 1, fields[4]))?;
+
+        // Normalize the Windows-style path and drop the leading model-id
+        // component to get a path relative to the firmware directory.
+        let normalized = dir_field.replace('\\', "/");
+        let mut path = String::new();
+
+        for component in normalized.split('/').skip(1) {
+            if component.is_empty() {
+                continue;
+            }
+            path.push_str(component);
+            path.push('/');
+        }
+        path.push_str(name);
+
+        entries.push(VerEntry { path, crc32, size });
+    }
+
+    if entries.is_empty() {
+        bail!("No file entries found in .ver file");
+    }
+
+    Ok(entries)
+}
+
+/// Find the single `.ver` file in `directory`.
+///
+/// Returns an error if there are zero or multiple `.ver` files.
+pub fn find_ver_file(directory: &Dir) -> Result<String> {
+    let mut found = None;
+
+    for entry in directory.entries().context("Failed to list directory")? {
+        let entry = entry.context("Failed to read directory entry")?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+
+        if name.ends_with(".ver") {
+            if found.is_some() {
+                bail!("Multiple .ver files found; specify one with --ver-file");
+            }
+            found = Some(name.into_owned());
+        }
+    }
+
+    found.ok_or_else(|| anyhow!("No .ver file found; specify one with --ver-file"))
+}
+
+/// Verify a single file entry against the file on disk.
+///
+/// `progress` is called with the number of bytes read after each chunk so the
+/// caller can update a progress bar. This never fails on a mismatch; it only
+/// returns an error for unexpected I/O failures.
+pub fn verify_entry(
+    directory: &Dir,
+    entry: &VerEntry,
+    mut progress: impl FnMut(u64),
+) -> Result<FileStatus> {
+    let mut file = match directory.open(Path::new(&entry.path)) {
+        Ok(f) => f,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(FileStatus::Missing),
+        Err(e) => {
+            return Err(e).with_context(|| format!("Failed to open file: {}", entry.path));
+        }
+    };
+
+    let mut hasher = Hasher::new();
+    let mut actual_size = 0u64;
+    let mut buf = [0u8; 8192];
+
+    loop {
+        let n = file
+            .read(&mut buf)
+            .with_context(|| format!("Failed to read file: {}", entry.path))?;
+        if n == 0 {
+            break;
+        }
+
+        hasher.update(&buf[..n]);
+        actual_size += n as u64;
+        progress(n as u64);
+    }
+
+    if actual_size != entry.size {
+        return Ok(FileStatus::SizeMismatch {
+            expected: entry.size,
+            actual: actual_size,
+        });
+    }
+
+    let digest = hasher.finalize();
+    if digest != entry.crc32 {
+        return Ok(FileStatus::CrcMismatch {
+            expected: entry.crc32,
+            actual: digest,
+        });
+    }
+
+    Ok(FileStatus::Ok)
+}


### PR DESCRIPTION
Adds the `nudl verify` command, which verifies already downloaded updates.

I had this usecase: I downloaded the update to my macbook, but then later copied it to a usb drive to actually use it, and wanted to verify if the copy was okay.

This change was created mosty by claude opus, I have manually verified the functionality, by manually corrupting a file in the downloaded update, the error was caught.

It uses the verify files present in the download, no server connection required. I have tested this with the update files for my kia ev6.