### PR TITLE
Add support for verifying existing firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, download nudl from the [releases page](https://github.com/chenxiaolong/nu
 
 Then, to list the available vehicle models and firmware versions, run:
 
-```
+```bash
 nudl list -b <brand>
 ```
 
@@ -24,13 +24,13 @@ where `<brand>` is `hyundai`, `kia`, or `genesis`.
 
 To download the latest firmware for a vehicle, run:
 
-```
+```bash
 nudl download -b <brand> -m <model> -o <output directory>
 ```
 
 If a model has multiple variants that share the same model ID (for example, HEV vs PHEV), `nudl download` will error and list the available firmware versions. Disambiguate by specifying the model name or exact firmware version shown by `nudl list`:
 
-```
+```bash
 nudl download -b <brand> -m <model> -n <model name>
 # Or
 nudl download -b <brand> -m <model> -v <firmware version>
@@ -58,13 +58,25 @@ Note that the progress bars may sometimes be misleading (eg. `32.73 GiB / 10.60 
 
 For more information about other command-line arguments, see `--help`.
 
+## Verifying existing firmware
+
+To verify an existing firmware directory against the checksums contained inside the `<model>.ver` file, run:
+
+```bash
+nudl verify -d <directory>
+```
+
+Verification normally happens as part of the download process, but this command can be useful for verifying the integrity of the files after the firmware has been copied elsewhere (e.g. to a USB drive). The car itself also checks file integrity before installation.
+
+Verifying existing firmware does not require network access.
+
 ## Building from source
 
 To build from source, first make sure that the Rust toolchain is installed. It can be installed from https://rustup.rs/ or the OS's package manager.
 
 Build nudl using the following command:
 
-```
+```bash
 cargo build --release
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{fmt, path::PathBuf, str::FromStr};
@@ -130,6 +130,13 @@ impl FirmwareSelectorGroup {
     }
 }
 
+#[derive(Debug, Args)]
+pub struct NetworkGroup {
+    /// Ignore TLS certificate validation for HTTPS connections.
+    #[arg(long)]
+    pub ignore_tls_validation: bool,
+}
+
 /// List available firmware.
 #[derive(Debug, Parser)]
 pub struct ListCli {
@@ -146,6 +153,9 @@ pub struct ListCli {
     /// `json-raw`: Raw data from the server.
     #[arg(short, long, default_value_t = OutputFormat::Text)]
     pub output: OutputFormat,
+
+    #[command(flatten)]
+    pub network: NetworkGroup,
 }
 
 /// Download firmware.
@@ -174,12 +184,30 @@ pub struct DownloadCli {
     /// Keep raw unextracted files.
     #[arg(short, long)]
     pub keep_raw: bool,
+
+    #[command(flatten)]
+    pub network: NetworkGroup,
+}
+
+/// Verify CRC32 of existing firmware.
+#[derive(Debug, Parser)]
+pub struct VerifyCli {
+    /// Firmware directory.
+    #[arg(short, long, value_parser, default_value = ".")]
+    pub directory: PathBuf,
+
+    /// Verification concurrency.
+    ///
+    /// The maximum concurrency allowed is 16.
+    #[arg(short, long, default_value = "4")]
+    pub concurrency: Concurrency,
 }
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
     List(ListCli),
     Download(DownloadCli),
+    Verify(VerifyCli),
 }
 
 #[derive(Debug, Parser)]
@@ -191,8 +219,4 @@ pub struct Cli {
     /// Lowest log message severity to output.
     #[arg(long, global = true, value_name = "LEVEL", default_value_t = Level::INFO)]
     pub log_level: Level,
-
-    /// Ignore TLS certificate validation for HTTPS connections.
-    #[arg(long, global = true)]
-    pub ignore_tls_validation: bool,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -103,6 +103,22 @@ pub enum BrandInfo {
     Unknown(String),
 }
 
+impl BrandInfo {
+    pub fn new(brand: &str) -> Self {
+        match Brand::from_str(brand) {
+            Ok(b) => Self::Known(b),
+            Err(b) => Self::Unknown(b),
+        }
+    }
+
+    pub fn as_code_str(&self) -> &str {
+        match self {
+            Self::Known(b) => b.as_code_str(),
+            Self::Unknown(b) => b.as_str(),
+        }
+    }
+}
+
 impl Serialize for BrandInfo {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -146,11 +162,6 @@ impl TryFrom<Car> for CarInfo {
             return Err(Error::BadFieldLength("sw_vers", car.sw_vers.len()));
         }
 
-        let brand = match Brand::from_str(&car.brand) {
-            Ok(b) => BrandInfo::Known(b),
-            Err(b) => BrandInfo::Unknown(b),
-        };
-
         // The marketing name sometimes includes NBSP (\u00a0).
         let name = car
             .dvc_name
@@ -159,7 +170,7 @@ impl TryFrom<Car> for CarInfo {
             .collect::<String>();
 
         Ok(Self {
-            brand,
+            brand: BrandInfo::new(&car.brand),
             id: car.dest_path,
             code: car.download_code,
             model: car.vcl_name,
@@ -167,15 +178,6 @@ impl TryFrom<Car> for CarInfo {
             versions: car.sw_vers,
             mcode: car.mcode,
         })
-    }
-}
-
-impl CarInfo {
-    pub fn brand(&self) -> &str {
-        match &self.brand {
-            BrandInfo::Known(b) => b.as_code_str(),
-            BrandInfo::Unknown(b) => b.as_str(),
-        }
     }
 }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
@@ -31,7 +31,10 @@ use zipunsplitlib::{
     split,
 };
 
-use crate::client::{self, CarInfo, FirmwareInfo, NuClient};
+use crate::{
+    client::{self, CarInfo, FirmwareInfo, NuClient},
+    version::VersionInfo,
+};
 
 const DOWNLOAD_EXT: &str = concat!(env!("CARGO_PKG_NAME"), "_download");
 const EXTRACT_EXT: &str = concat!(env!("CARGO_PKG_NAME"), "_extract");
@@ -186,56 +189,13 @@ impl Downloader {
         (result, progress_rx)
     }
 
-    /// Compute contents of version info file.
-    fn version_file(car: &CarInfo, firmware: &FirmwareInfo) -> String {
-        use std::fmt::Write;
-
-        let mut result = String::new();
-
-        writeln!(
-            &mut result,
-            "+|{}|{}|{}|{}|{}|1",
-            firmware.update_version,
-            // The official app always puts the first listed version number in
-            // this file. All output files are exactly identical regardless of
-            // which firmware version the user selects for the same model ID.
-            car.versions[0],
-            car.brand(),
-            car.id,
-            car.mcode,
-        )
-        .unwrap();
-
-        for file in &firmware.files {
-            let mut directory = String::new();
-            if let Some(name) = &file.directory {
-                directory.push('\\');
-                directory.push_str(&name.replace('/', "\\"));
-            }
-
-            writeln!(
-                &mut result,
-                "{}{directory}|{}|{}|{}|{}|1",
-                car.id,
-                file.name,
-                file.version,
-                file.crc32 as i32,
-                // This is signed in the raw response, but unsigned here.
-                file.size,
-            )
-            .unwrap();
-        }
-
-        result
-    }
-
     /// Write version info file to [`CarInfo::id`]`.ver`.
     fn write_version_file(directory: &Dir, car: &CarInfo, firmware: &FirmwareInfo) -> Result<()> {
         let path = format!("{}.ver", car.id);
-        let contents = Self::version_file(car, firmware);
+        let info = VersionInfo::new(car, firmware);
 
         directory
-            .write(&path, contents)
+            .write(&path, info.to_string())
             .with_context(|| format!("Failed to write file: {path}"))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 mod cli;
@@ -8,6 +8,8 @@ mod crypto;
 mod download;
 mod model;
 mod progress;
+mod verify;
+mod version;
 
 use std::{
     fmt::{self, Display, Write as _},
@@ -25,10 +27,11 @@ use tracing::debug;
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
-    cli::{Brand, Cli, Command, DownloadCli, ListCli, OutputFormat},
+    cli::{Brand, Cli, Command, DownloadCli, ListCli, OutputFormat, VerifyCli},
     client::{CarInfo, NuClient, NuClientBuilder},
     download::{Downloader, ProgressMessage},
     progress::{ProgressSuspendingStderr, SpeedTracker},
+    verify::Verifier,
 };
 
 const PROGRESS_SPEED_WINDOW: Duration = Duration::from_secs(1);
@@ -120,18 +123,18 @@ impl fmt::Display for Selector {
     }
 }
 
-async fn list_subcommand(cli: &Cli, list_cli: &ListCli) -> Result<()> {
+async fn list_subcommand(cli: &ListCli) -> Result<()> {
     let (client, region, guid) = prepare_client(
-        list_cli.family.brand,
-        list_cli.family.region.as_deref(),
-        cli.ignore_tls_validation,
+        cli.family.brand,
+        cli.family.region.as_deref(),
+        cli.network.ignore_tls_validation,
     )
     .await?;
-    let brand = list_cli.family.brand.as_code_str();
-    let selectors = list_cli.selector.to_selectors();
+    let brand = cli.family.brand.as_code_str();
+    let selectors = cli.selector.to_selectors();
     let mut stdout = io::stdout().lock();
 
-    match list_cli.output {
+    match cli.output {
         OutputFormat::Text => {
             const HEADING_MODEL: &str = "MODEL";
             const HEADING_NAME: &str = "NAME";
@@ -202,22 +205,18 @@ async fn list_subcommand(cli: &Cli, list_cli: &ListCli) -> Result<()> {
     Ok(())
 }
 
-async fn download_subcommand(
-    cli: &Cli,
-    download_cli: &DownloadCli,
-    bars: MultiProgress,
-) -> Result<()> {
+async fn download_subcommand(cli: &DownloadCli, bars: MultiProgress) -> Result<()> {
     let (client, region, guid) = prepare_client(
-        download_cli.family.brand,
-        download_cli.family.region.as_deref(),
-        cli.ignore_tls_validation,
+        cli.family.brand,
+        cli.family.region.as_deref(),
+        cli.network.ignore_tls_validation,
     )
     .await?;
 
     let cars = client
-        .get_cars(&region, &guid, download_cli.family.brand.as_code_str())
+        .get_cars(&region, &guid, cli.family.brand.as_code_str())
         .await?;
-    let selectors = download_cli.selector.to_selectors();
+    let selectors = cli.selector.to_selectors();
     let candidates: Vec<_> = cars
         .iter()
         .filter(|c| selectors.iter().all(|s| s.matches_car(c)))
@@ -268,7 +267,7 @@ async fn download_subcommand(
 
     println!("ID: {}", car.id);
     println!("Region: {region}");
-    println!("Brand: {}", car.brand());
+    println!("Brand: {}", car.brand.as_code_str());
     println!("Model: {}", car.name);
     println!("Version: {}", join(&car.versions, ", "));
     println!("Size: {} bytes", firmware.size);
@@ -281,10 +280,10 @@ async fn download_subcommand(
     }
 
     let authority = ambient_authority();
-    Dir::create_ambient_dir_all(&download_cli.output, authority)
-        .with_context(|| format!("Failed to create directory: {:?}", download_cli.output))?;
-    let directory = Dir::open_ambient_dir(&download_cli.output, authority)
-        .with_context(|| format!("Failed to open directory: {:?}", download_cli.output))?;
+    Dir::create_ambient_dir_all(&cli.output, authority)
+        .with_context(|| format!("Failed to create directory: {:?}", cli.output))?;
+    let directory = Dir::open_ambient_dir(&cli.output, authority)
+        .with_context(|| format!("Failed to open directory: {:?}", cli.output))?;
 
     // The progress will be misreported if files are modified by external
     // processes. Solving this requires sending HEAD requests for each split and
@@ -307,9 +306,9 @@ async fn download_subcommand(
         client,
         car.clone(),
         firmware,
-        download_cli.concurrency.0.into(),
-        download_cli.retries,
-        download_cli.keep_raw,
+        cli.concurrency.0.into(),
+        cli.retries,
+        cli.keep_raw,
     );
     let handle = downloader.download();
     tokio::pin!(handle);
@@ -353,6 +352,54 @@ async fn download_subcommand(
     Ok(())
 }
 
+async fn verify_subcommand(cli: &VerifyCli, bars: MultiProgress) -> Result<()> {
+    let authority = ambient_authority();
+    let directory = Dir::open_ambient_dir(&cli.directory, authority)
+        .with_context(|| format!("Failed to open directory: {:?}", cli.directory))?;
+
+    let mut p_verify_current = 0;
+    let p_verify = bars.add(ProgressBar::hidden());
+    p_verify.set_prefix("Verify");
+    p_verify.set_style(progress_style());
+
+    let (verifier, mut p_rx) = Verifier::new(directory, cli.concurrency.0.into());
+    let handle = verifier.verify();
+    tokio::pin!(handle);
+
+    loop {
+        tokio::select! {
+            c = ctrl_c() => {
+                let _ = bars.clear();
+                c?;
+
+                bail!("Verification was interrupted");
+            }
+            r = &mut handle => {
+                let _ = bars.clear();
+                r?;
+                break;
+            }
+            p = p_rx.recv() => {
+                if let Some(msg) = p {
+                    match msg {
+                        ProgressMessage::TotalDownload(_) => {}
+                        ProgressMessage::TotalPostProcess(bytes) => {
+                            p_verify.set_length(bytes);
+                        }
+                        ProgressMessage::Download(_) => {}
+                        ProgressMessage::PostProcess(bytes) => {
+                            p_verify_current += bytes;
+                            p_verify.set_position(p_verify_current);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -372,7 +419,8 @@ async fn main() -> Result<()> {
         .map_err(|_| anyhow!("Failed to set up ring as rustls crypto provider"))?;
 
     match &cli.command {
-        Command::List(c) => list_subcommand(&cli, c).await,
-        Command::Download(c) => download_subcommand(&cli, c, bars).await,
+        Command::List(c) => list_subcommand(c).await,
+        Command::Download(c) => download_subcommand(c, bars).await,
+        Command::Verify(c) => verify_subcommand(c, bars).await,
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{
+    collections::VecDeque,
+    io::{self, Read, Seek, SeekFrom},
+    sync::{Arc, atomic::AtomicBool},
+};
+
+use cap_std::fs::Dir;
+use crc32fast::Hasher;
+use thiserror::Error;
+use tokio::{
+    sync::mpsc::{self, error::SendError},
+    task::{self, JoinError, JoinSet},
+};
+use tracing::{debug, error};
+
+use crate::{
+    download::{CancelOnDrop, ProgressMessage, check_cancel},
+    version::{self, VersionEntry, VersionInfo},
+};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Failed to list directory")]
+    ListDir(#[source] io::Error),
+    #[error("Firmware directory must contain exactly one .ver file")]
+    InvalidVerFileCount,
+    #[error("Invalid .ver file: {0:?}")]
+    InvalidVerFile(String, #[source] version::Error),
+    #[error("Failed to open file: {0:?}")]
+    OpenFile(String, #[source] io::Error),
+    #[error("Failed to read file: {0:?}")]
+    ReadFile(String, #[source] io::Error),
+    #[error("Expected size {expected}, but have {actual}: {path:?}")]
+    InvalidSize {
+        path: String,
+        actual: u64,
+        expected: u64,
+    },
+    #[error("Expected CRC32 {expected:08X}, but have {actual:08X}: {path:?}")]
+    InvalidCrc32 {
+        path: String,
+        actual: u32,
+        expected: u32,
+    },
+    #[error("Verification failed")]
+    Failed,
+    #[error(transparent)]
+    Progress(SendError<ProgressMessage>),
+    #[error(transparent)]
+    Cancelled(io::Error),
+    #[error(transparent)]
+    Panic(JoinError),
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct Verifier {
+    directory: Arc<Dir>,
+    concurrency: usize,
+    progress_tx: mpsc::Sender<ProgressMessage>,
+}
+
+impl Verifier {
+    pub fn new(directory: Dir, concurrency: usize) -> (Self, mpsc::Receiver<ProgressMessage>) {
+        let (progress_tx, progress_rx) = mpsc::channel(2 * concurrency);
+
+        let result = Self {
+            directory: Arc::new(directory),
+            concurrency,
+            progress_tx,
+        };
+
+        (result, progress_rx)
+    }
+
+    fn read_version_file(directory: &Dir) -> Result<VersionInfo> {
+        let mut ver_file = None;
+
+        for entry in directory.entries().map_err(Error::ListDir)? {
+            let entry = entry.map_err(Error::ListDir)?;
+            let Ok(name) = entry.file_name().into_string() else {
+                continue;
+            };
+
+            if name.ends_with(".ver") {
+                if ver_file.is_some() {
+                    return Err(Error::InvalidVerFileCount);
+                }
+
+                let contents = directory
+                    .read_to_string(&name)
+                    .map_err(|e| Error::ReadFile(name.to_owned(), e))?;
+
+                ver_file = Some((name, contents));
+            }
+        }
+
+        let (ver_name, ver_contents) = ver_file.ok_or_else(|| Error::InvalidVerFileCount)?;
+
+        ver_contents
+            .parse::<VersionInfo>()
+            .map_err(|e| Error::InvalidVerFile(ver_name.to_owned(), e))
+    }
+
+    fn verify_entry(
+        directory: &Dir,
+        entry: &VersionEntry,
+        progress_tx: mpsc::Sender<ProgressMessage>,
+        cancel_signal: &AtomicBool,
+    ) -> Result<()> {
+        let path = entry.path();
+
+        let mut file = directory
+            .open(path.as_ref())
+            .map_err(|e| Error::OpenFile(path.clone().into_owned(), e))?;
+
+        let size = file
+            .seek(SeekFrom::End(0))
+            .and_then(|s| file.rewind().map(|_| s))
+            .map_err(|e| Error::ReadFile(path.clone().into_owned(), e))?;
+
+        if size != entry.size {
+            return Err(Error::InvalidSize {
+                path: path.into_owned(),
+                actual: size,
+                expected: entry.size,
+            });
+        }
+
+        let mut hasher = Hasher::new();
+        let mut buf = [0u8; 8192];
+
+        loop {
+            check_cancel(cancel_signal).map_err(Error::Cancelled)?;
+
+            let n = file
+                .read(&mut buf)
+                .map_err(|e| Error::ReadFile(path.clone().into_owned(), e))?;
+            if n == 0 {
+                break;
+            }
+
+            hasher.update(&buf[..n]);
+
+            progress_tx
+                .blocking_send(ProgressMessage::PostProcess(n as u64))
+                .map_err(Error::Progress)?;
+        }
+
+        let digest = hasher.finalize();
+        if digest != entry.crc32 {
+            return Err(Error::InvalidCrc32 {
+                path: path.into_owned(),
+                actual: digest,
+                expected: entry.crc32,
+            });
+        }
+
+        Ok(())
+    }
+
+    async fn verify_entry_task(
+        task_id: usize,
+        directory: Arc<Dir>,
+        entry: VersionEntry,
+        progress_tx: mpsc::Sender<ProgressMessage>,
+    ) -> (usize, Result<()>) {
+        let cancel_on_drop = CancelOnDrop::new();
+        let cancel_signal = cancel_on_drop.handle();
+
+        let result = task::spawn_blocking(move || {
+            Self::verify_entry(&directory, &entry, progress_tx, &cancel_signal)
+        })
+        .await
+        .map_err(Error::Panic)
+        .flatten();
+
+        (task_id, result)
+    }
+
+    pub async fn verify(&self) -> Result<()> {
+        // Read version info file. This is not cancellable because it's a
+        // single read operation.
+        let info = task::spawn_blocking({
+            let directory = self.directory.clone();
+            move || Self::read_version_file(&directory)
+        })
+        .await
+        .map_err(Error::Panic)
+        .flatten()?;
+
+        let mut entries = VecDeque::from(info.entries);
+        let total_size = entries.iter().map(|e| e.size).sum();
+
+        // Report initial progress.
+        self.progress_tx
+            .send(ProgressMessage::TotalPostProcess(total_size))
+            .await
+            .map_err(Error::Progress)?;
+        self.progress_tx
+            .send(ProgressMessage::PostProcess(0))
+            .await
+            .map_err(Error::Progress)?;
+
+        let mut tasks = JoinSet::new();
+        let mut next_task_id = 0;
+        let mut running = 0;
+        let mut failed = 0;
+
+        loop {
+            while running < self.concurrency {
+                let Some(entry) = entries.pop_front() else {
+                    break;
+                };
+
+                let task_id = next_task_id;
+                next_task_id += 1;
+
+                debug!("[Verify#{task_id}] Task starting");
+                running += 1;
+                tasks.spawn(Self::verify_entry_task(
+                    task_id,
+                    self.directory.clone(),
+                    entry,
+                    self.progress_tx.clone(),
+                ));
+            }
+
+            let (task_id, task_result) = match tasks.join_next().await {
+                // All tasks exited.
+                None => break,
+                // Task panicked or cancelled.
+                Some(Err(e)) => return Err(Error::Panic(e)),
+                // Task completed.
+                Some(Ok((id, result))) => (id, result),
+            };
+
+            debug!("[Verify#{task_id}] Task completed");
+            running -= 1;
+
+            if let Err(e) = task_result {
+                error!("{:#}", anyhow::Error::from(e));
+                failed += 1;
+            }
+        }
+
+        if failed > 0 {
+            return Err(Error::Failed);
+        }
+
+        Ok(())
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{borrow::Cow, fmt, str::FromStr};
+
+use thiserror::Error;
+
+use crate::client::{BrandInfo, CarInfo, FirmwareInfo};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Version file is empty")]
+    EmptyFile,
+    #[error("Malformed version header line: {0:?}")]
+    MalformedHeader(String),
+    #[error("Malformed version entry line: {0:?}")]
+    MalformedEntry(String),
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct VersionHeader {
+    pub update_version: String,
+    pub firmware_version: String,
+    pub brand: BrandInfo,
+    pub id: String,
+    pub mcode: String,
+}
+
+impl fmt::Display for VersionHeader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "+|{}|{}|{}|{}|{}|1",
+            self.update_version,
+            self.firmware_version,
+            self.brand.as_code_str(),
+            self.id,
+            self.mcode,
+        )
+    }
+}
+
+impl FromStr for VersionHeader {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        fn parse(s: &str) -> Option<VersionHeader> {
+            let mut iter = s.split('|');
+
+            let plus = iter.next()?;
+            if plus != "+" {
+                return None;
+            }
+
+            let update_version = iter.next()?;
+            let firmware_version = iter.next()?;
+            let brand = iter.next()?;
+            let id = iter.next()?;
+            let mcode = iter.next()?;
+
+            let completed = iter.next()?;
+            if completed != "1" {
+                return None;
+            }
+
+            if iter.next().is_some() {
+                return None;
+            }
+
+            Some(VersionHeader {
+                update_version: update_version.to_owned(),
+                firmware_version: firmware_version.to_owned(),
+                brand: BrandInfo::new(brand),
+                id: id.to_owned(),
+                mcode: mcode.to_owned(),
+            })
+        }
+
+        parse(s).ok_or_else(|| Error::MalformedHeader(s.to_owned()))
+    }
+}
+
+pub struct VersionEntry {
+    pub id: String,
+    pub directory: Option<String>,
+    pub filename: String,
+    pub version: String,
+    pub crc32: u32,
+    pub size: u64,
+}
+
+impl VersionEntry {
+    pub fn path(&self) -> Cow<'_, str> {
+        match &self.directory {
+            Some(d) => Cow::Owned(format!("{d}/{}", self.filename)),
+            None => Cow::Borrowed(&self.filename),
+        }
+    }
+}
+
+impl fmt::Display for VersionEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.id)?;
+
+        if let Some(path) = &self.directory {
+            for component in path.split('/') {
+                f.write_str("\\")?;
+                f.write_str(component)?;
+            }
+        }
+
+        write!(
+            f,
+            "|{}|{}|{}|{}|1",
+            self.filename, self.version, self.crc32 as i32, self.size,
+        )
+    }
+}
+
+impl FromStr for VersionEntry {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        fn parse(s: &str) -> Option<VersionEntry> {
+            let mut iter = s.split('|');
+
+            let id_directory = iter.next()?;
+            let (id, directory) = match id_directory.split_once('\\') {
+                Some((i, d)) => (i, Some(d.replace("\\", "/"))),
+                None => (id_directory, None),
+            };
+
+            let filename = iter.next()?;
+            let version = iter.next()?;
+            let crc32 = iter.next()?.parse::<i32>().ok()? as u32;
+            let size = iter.next()?.parse::<u64>().ok()?;
+
+            let completed = iter.next()?;
+            if completed != "1" {
+                return None;
+            }
+
+            if iter.next().is_some() {
+                return None;
+            }
+
+            Some(VersionEntry {
+                id: id.to_owned(),
+                directory,
+                filename: filename.to_owned(),
+                version: version.to_owned(),
+                crc32,
+                size,
+            })
+        }
+
+        parse(s).ok_or_else(|| Error::MalformedEntry(s.to_owned()))
+    }
+}
+
+pub struct VersionInfo {
+    pub header: VersionHeader,
+    pub entries: Vec<VersionEntry>,
+}
+
+impl VersionInfo {
+    pub fn new(car: &CarInfo, firmware: &FirmwareInfo) -> Self {
+        let header = VersionHeader {
+            update_version: firmware.update_version.clone(),
+            // The official app always puts the first listed version number in
+            // this file. All output files are exactly identical regardless of
+            // which firmware version the user selects for the same model ID.
+            firmware_version: car.versions[0].clone(),
+            brand: car.brand.clone(),
+            id: car.id.clone(),
+            mcode: car.mcode.clone(),
+        };
+
+        let mut entries = vec![];
+
+        for file in &firmware.files {
+            entries.push(VersionEntry {
+                id: car.id.clone(),
+                directory: file.directory.clone(),
+                filename: file.name.clone(),
+                version: file.version.clone(),
+                crc32: file.crc32,
+                size: file.size,
+            });
+        }
+
+        Self { header, entries }
+    }
+}
+
+impl fmt::Display for VersionInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", self.header)?;
+
+        for entry in &self.entries {
+            writeln!(f, "{entry}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl FromStr for VersionInfo {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut iter = s.split_terminator("\n");
+
+        let header = iter
+            .next()
+            .ok_or(Error::EmptyFile)?
+            .parse::<VersionHeader>()?;
+
+        let mut entries = vec![];
+
+        for line in iter {
+            entries.push(line.parse::<VersionEntry>()?);
+        }
+
+        Ok(Self { header, entries })
+    }
+}


### PR DESCRIPTION
This adds a new `nudl verify` subcommand for verifying the integrity of an existing firmware directory. Similar to the download subcommand, concurrent verification is supported.

(This is a rewrite of #59 with additional functionality.)

Co-authored-by: @yourfate