### PR TITLE
Add support for OSC 9;4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle-progress"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082ebe8b7607a68881fbcccc7b3a3e784aa58593ed4261df0679a803fdb80853"
+
+[[package]]
 name = "anstyle-query"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1041,7 @@ name = "nudl"
 version = "1.0.1"
 dependencies = [
  "aes",
+ "anstyle-progress",
  "anyhow",
  "base64 0.23.0",
  "block-padding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ publish.workspace = true
 
 [dependencies]
 aes = "0.9.0"
+anstyle-progress = "0.1.4"
 anyhow = "1.0.80"
 base64 = "0.23.0"
 block-padding = "0.4.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use crate::{
     cli::{Brand, Cli, Command, DownloadCli, ListCli, OutputFormat, VerifyCli},
     client::{CarInfo, NuClient, NuClientBuilder},
     download::{Downloader, ProgressMessage},
-    progress::{ProgressSuspendingStderr, SpeedTracker},
+    progress::{Osc94, Osc94Printer, ProgressSuspendingStderr, SpeedTracker, progress_percentage},
     verify::Verifier,
 };
 
@@ -291,12 +291,13 @@ async fn download_subcommand(cli: &DownloadCli, bars: MultiProgress) -> Result<(
     // would be corrupt anyway and the progress bar is the least of the user's
     // concerns.
 
-    let mut p_dl_current = 0;
+    let mut osc94 = Osc94Printer::new();
+    osc94.update(Osc94::Indeterminate);
+
     let p_dl = bars.add(ProgressBar::hidden());
     p_dl.set_prefix("Download");
     p_dl.set_style(progress_style());
 
-    let mut p_pp_current = 0;
     let p_pp = bars.add(ProgressBar::hidden());
     p_pp.set_prefix("Post-process");
     p_pp.set_style(progress_style());
@@ -336,14 +337,24 @@ async fn download_subcommand(cli: &DownloadCli, bars: MultiProgress) -> Result<(
                             p_pp.set_length(bytes);
                         }
                         ProgressMessage::Download(bytes) => {
-                            p_dl_current += bytes;
-                            p_dl.set_position(p_dl_current);
+                            p_dl.inc(bytes);
                         }
                         ProgressMessage::PostProcess(bytes) => {
-                            p_pp_current += bytes;
-                            p_pp.set_position(p_pp_current);
+                            p_pp.inc(bytes);
                         }
                     }
+
+                    let osc94_bars: &[&ProgressBar] = if p_pp.length() == Some(0) {
+                        // If the server won't tell us the total extracted size,
+                        // then don't include post-processing progress since
+                        // otherwise the OSC 9;4 progress will always be more
+                        // than halfway complete.
+                        &[&p_dl]
+                    } else {
+                        &[&p_dl, &p_pp]
+                    };
+
+                    osc94.update(Osc94::Normal(progress_percentage(osc94_bars)));
                 }
             }
         }
@@ -357,7 +368,9 @@ async fn verify_subcommand(cli: &VerifyCli, bars: MultiProgress) -> Result<()> {
     let directory = Dir::open_ambient_dir(&cli.directory, authority)
         .with_context(|| format!("Failed to open directory: {:?}", cli.directory))?;
 
-    let mut p_verify_current = 0;
+    let mut osc94 = Osc94Printer::new();
+    osc94.update(Osc94::Indeterminate);
+
     let p_verify = bars.add(ProgressBar::hidden());
     p_verify.set_prefix("Verify");
     p_verify.set_style(progress_style());
@@ -388,10 +401,11 @@ async fn verify_subcommand(cli: &VerifyCli, bars: MultiProgress) -> Result<()> {
                         }
                         ProgressMessage::Download(_) => {}
                         ProgressMessage::PostProcess(bytes) => {
-                            p_verify_current += bytes;
-                            p_verify.set_position(p_verify_current);
+                            p_verify.inc(bytes);
                         }
                     }
+
+                    osc94.update(Osc94::Normal(progress_percentage(&[&p_verify])));
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,7 +354,7 @@ async fn download_subcommand(cli: &DownloadCli, bars: MultiProgress) -> Result<(
                         &[&p_dl, &p_pp]
                     };
 
-                    osc94.update(Osc94::Normal(progress_percentage(osc94_bars)));
+                    osc94.update(Osc94::Determinate(progress_percentage(osc94_bars)));
                 }
             }
         }
@@ -405,7 +405,7 @@ async fn verify_subcommand(cli: &VerifyCli, bars: MultiProgress) -> Result<()> {
                         }
                     }
 
-                    osc94.update(Osc94::Normal(progress_percentage(&[&p_verify])));
+                    osc94.update(Osc94::Determinate(progress_percentage(&[&p_verify])));
                 }
             }
         }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,14 +1,14 @@
-// SPDX-FileCopyrightText: 2020-2024 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2020-2026 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
     collections::VecDeque,
     fmt,
-    io::{self, IoSlice, Write},
+    io::{self, IoSlice, IsTerminal, Write},
     time::{Duration, Instant},
 };
 
-use indicatif::{BinaryBytes, MultiProgress, ProgressState, style::ProgressTracker};
+use indicatif::{BinaryBytes, MultiProgress, ProgressBar, ProgressState, style::ProgressTracker};
 use tracing_subscriber::fmt::MakeWriter;
 
 /// Type that receives progress values and buffers them to compute the average
@@ -125,4 +125,85 @@ impl<'a> MakeWriter<'a> for ProgressSuspendingStderr {
     fn make_writer(&'a self) -> Self::Writer {
         self.clone()
     }
+}
+
+#[allow(unused)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[repr(u8)]
+pub enum Osc94 {
+    Hidden = 0,
+    Normal(u8) = 1,
+    Error(u8) = 2,
+    Indeterminate = 3,
+    Warning(u8) = 4,
+}
+
+impl fmt::Display for Osc94 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SAFETY: Primitive representation.
+        // https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.access-memory
+        let state = unsafe { *(self as *const Self).cast::<u8>() };
+
+        let progress = match self {
+            Self::Hidden | Self::Indeterminate => 0,
+            Self::Normal(p) | Self::Error(p) | Self::Warning(p) => 100.min(*p),
+        };
+
+        write!(f, "\x1b]9;4;{state};{progress}\x07")
+    }
+}
+
+#[derive(Clone)]
+pub struct Osc94Printer {
+    state: Osc94,
+    is_terminal: bool,
+}
+
+impl Osc94Printer {
+    pub fn new() -> Self {
+        Self {
+            state: Osc94::Hidden,
+            is_terminal: io::stderr().is_terminal(),
+        }
+    }
+
+    pub fn update(&mut self, state: Osc94) {
+        if self.state != state {
+            self.state = state;
+            if self.is_terminal {
+                // Max OSC 9;4 length is 14 bytes.
+                let mut buf = [0u8; 16];
+                let _ = write!(buf.as_mut_slice(), "{state}");
+                let n = buf.iter().position(|b| *b == 0).unwrap();
+
+                // Ensure the write is atomic.
+                let _ = io::stderr().write(&buf[..n]);
+            }
+        }
+    }
+}
+
+impl Drop for Osc94Printer {
+    fn drop(&mut self) {
+        self.update(Osc94::Hidden);
+    }
+}
+
+pub fn progress_percentage(bars: &[&ProgressBar]) -> u8 {
+    let ratio_sum = bars
+        .iter()
+        .map(|b| {
+            if let Some(l) = b.length()
+                && l > 0
+            {
+                b.position() as f64 / l as f64
+            } else if b.position() == 0 {
+                0f64
+            } else {
+                1f64
+            }
+        })
+        .sum::<f64>();
+
+    (ratio_sum / bars.len() as f64 * 100f64).round() as u8
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -8,6 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use anstyle_progress::TermProgress;
 use indicatif::{BinaryBytes, MultiProgress, ProgressBar, ProgressState, style::ProgressTracker};
 use tracing_subscriber::fmt::MakeWriter;
 
@@ -127,53 +128,40 @@ impl<'a> MakeWriter<'a> for ProgressSuspendingStderr {
     }
 }
 
-#[allow(unused)]
 #[derive(Clone, Copy, Eq, PartialEq)]
-#[repr(u8)]
 pub enum Osc94 {
-    Hidden = 0,
-    Normal(u8) = 1,
-    Error(u8) = 2,
-    Indeterminate = 3,
-    Warning(u8) = 4,
-}
-
-impl fmt::Display for Osc94 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // SAFETY: Primitive representation.
-        // https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.access-memory
-        let state = unsafe { *(self as *const Self).cast::<u8>() };
-
-        let progress = match self {
-            Self::Hidden | Self::Indeterminate => 0,
-            Self::Normal(p) | Self::Error(p) | Self::Warning(p) => 100.min(*p),
-        };
-
-        write!(f, "\x1b]9;4;{state};{progress}\x07")
-    }
+    Hidden,
+    Determinate(u8),
+    Indeterminate,
 }
 
 #[derive(Clone)]
 pub struct Osc94Printer {
     state: Osc94,
-    is_terminal: bool,
+    supported: bool,
 }
 
 impl Osc94Printer {
     pub fn new() -> Self {
         Self {
             state: Osc94::Hidden,
-            is_terminal: io::stderr().is_terminal(),
+            supported: anstyle_progress::supports_term_progress(io::stderr().is_terminal()),
         }
     }
 
     pub fn update(&mut self, state: Osc94) {
         if self.state != state {
             self.state = state;
-            if self.is_terminal {
-                // Max OSC 9;4 length is 14 bytes.
+            if self.supported {
+                let term_progress = match state {
+                    Osc94::Hidden => TermProgress::remove(),
+                    Osc94::Determinate(p) => TermProgress::start().percent(p.min(100)),
+                    Osc94::Indeterminate => TermProgress::start(),
+                };
+
+                // Max OSC 9;4 length is 13 bytes.
                 let mut buf = [0u8; 16];
-                let _ = write!(buf.as_mut_slice(), "{state}");
+                let _ = write!(buf.as_mut_slice(), "{term_progress}");
                 let n = buf.iter().position(|b| *b == 0).unwrap();
 
                 // Ensure the write is atomic.


### PR DESCRIPTION
This allows the download progress to be communicated to terminal emulators. Eg. Konsole and Windows Terminal can show the progress in the tab bar or taskbar icon.