### PR TITLE
Throttle progress updates

### DIFF
--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+pub struct CancelOnDrop(Arc<AtomicBool>);
+
+impl CancelOnDrop {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    pub fn handle(&self) -> Arc<AtomicBool> {
+        self.0.clone()
+    }
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+/// Returns an I/O error with the [`io::ErrorKind::Interrupted`] type if
+/// `cancel_signal` is true. This should be called frequently in I/O loops for
+/// cancellation to be responsive.
+#[inline]
+pub fn check_cancel(cancel_signal: &AtomicBool) -> io::Result<()> {
+    if cancel_signal.load(Ordering::SeqCst) {
+        return Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "Received cancel signal",
+        ));
+    }
+
+    Ok(())
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -5,10 +5,7 @@ use std::{
     collections::VecDeque,
     io::{self, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, atomic::AtomicBool},
     time::Duration,
 };
 
@@ -32,7 +29,9 @@ use zipunsplitlib::{
 };
 
 use crate::{
+    cancel::{CancelOnDrop, check_cancel},
     client::{self, CarInfo, FirmwareInfo, NuClient},
+    progress::{THROTTLE_DELAY, ThrottledProgress},
     version::VersionInfo,
 };
 
@@ -41,39 +40,6 @@ const EXTRACT_EXT: &str = concat!(env!("CARGO_PKG_NAME"), "_extract");
 const VERIFY_EXT: &str = concat!(env!("CARGO_PKG_NAME"), "_verify");
 
 const RETRY_DELAY: Duration = Duration::from_secs(1);
-
-pub struct CancelOnDrop(Arc<AtomicBool>);
-
-impl CancelOnDrop {
-    pub fn new() -> Self {
-        Self(Arc::new(AtomicBool::new(false)))
-    }
-
-    pub fn handle(&self) -> Arc<AtomicBool> {
-        self.0.clone()
-    }
-}
-
-impl Drop for CancelOnDrop {
-    fn drop(&mut self) {
-        self.0.store(true, Ordering::SeqCst);
-    }
-}
-
-/// Returns an I/O error with the [`io::ErrorKind::Interrupted`] type if
-/// `cancel_signal` is true. This should be called frequently in I/O loops for
-/// cancellation to be responsive.
-#[inline]
-pub fn check_cancel(cancel_signal: &AtomicBool) -> io::Result<()> {
-    if cancel_signal.load(Ordering::SeqCst) {
-        return Err(io::Error::new(
-            io::ErrorKind::Interrupted,
-            "Received cancel signal",
-        ));
-    }
-
-    Ok(())
-}
 
 /// Delete a file, but don't error out if the path doesn't exist.
 fn delete_if_exists(directory: &Dir, path: &Path) -> Result<()> {
@@ -343,6 +309,9 @@ impl Downloader {
             Err(e) => return Err(e.into()),
         };
 
+        let mut progress =
+            ThrottledProgress::new(progress_tx, ProgressMessage::Download, THROTTLE_DELAY);
+
         while let Some(data) = stream.next().await {
             let data = data?;
             trace!("[{path}] Received {} bytes", data.len());
@@ -351,10 +320,10 @@ impl Downloader {
                 .await
                 .with_context(|| format!("Failed to write {} bytes", data.len()))?;
 
-            progress_tx
-                .send(ProgressMessage::Download(data.len() as u64))
-                .await?;
+            progress.update(data.len() as u64).await?;
         }
+
+        progress.flush().await?;
 
         file.sync_all().await.context("Failed to sync file")?;
 
@@ -439,7 +408,7 @@ impl Downloader {
                 }
                 Err(e) => {
                     warn!(
-                        "[Attempt #{}/{}] Failed to download to: {download_path}: {e:?}",
+                        "[Attempt #{}/{}] Failed to download to: {download_path}: {e:#}",
                         attempt + 1,
                         u16::from(retries) + 1,
                     );
@@ -507,6 +476,9 @@ impl Downloader {
         let mut hasher = Hasher::new();
         let mut buf = [0u8; 8192];
 
+        let mut progress =
+            ThrottledProgress::new(progress_tx, ProgressMessage::PostProcess, THROTTLE_DELAY);
+
         loop {
             check_cancel(cancel_signal)?;
 
@@ -519,8 +491,10 @@ impl Downloader {
 
             hasher.update(&buf[..n]);
 
-            progress_tx.blocking_send(ProgressMessage::PostProcess(n as u64))?;
+            progress.update_blocking(n as u64)?;
         }
+
+        progress.flush_blocking()?;
 
         let digest = hasher.finalize();
         if digest != file_info.crc32 {
@@ -635,6 +609,9 @@ impl Downloader {
             .with_context(|| format!("Failed to create file: {extract_path}"))?;
         let mut buf = [0u8; 8192];
 
+        let mut progress =
+            ThrottledProgress::new(progress_tx, ProgressMessage::PostProcess, THROTTLE_DELAY);
+
         loop {
             check_cancel(cancel_signal)?;
 
@@ -648,8 +625,10 @@ impl Downloader {
             file.write_all(&buf[..n])
                 .with_context(|| format!("Failed to write data: {extract_path}"))?;
 
-            progress_tx.blocking_send(ProgressMessage::PostProcess(n as u64))?;
+            progress.update_blocking(n as u64)?;
         }
+
+        progress.flush_blocking()?;
 
         check_cancel(cancel_signal)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
+mod cancel;
 mod cli;
 mod client;
 mod constants;
@@ -29,7 +30,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::{
     cli::{Brand, Cli, Command, DownloadCli, ListCli, OutputFormat, VerifyCli},
     client::{CarInfo, NuClient, NuClientBuilder},
-    download::{Downloader, ProgressMessage},
+    download::Downloader,
     progress::{Osc94, Osc94Printer, ProgressSuspendingStderr, SpeedTracker, progress_percentage},
     verify::Verifier,
 };
@@ -316,6 +317,8 @@ async fn download_subcommand(cli: &DownloadCli, bars: MultiProgress) -> Result<(
 
     loop {
         tokio::select! {
+            biased;
+
             c = ctrl_c() => {
                 let _ = bars.clear();
                 c?;
@@ -330,16 +333,16 @@ async fn download_subcommand(cli: &DownloadCli, bars: MultiProgress) -> Result<(
             p = p_rx.recv() => {
                 if let Some(msg) = p {
                     match msg {
-                        ProgressMessage::TotalDownload(bytes) => {
+                        download::ProgressMessage::TotalDownload(bytes) => {
                             p_dl.set_length(bytes);
                         }
-                        ProgressMessage::TotalPostProcess(bytes) => {
+                        download::ProgressMessage::TotalPostProcess(bytes) => {
                             p_pp.set_length(bytes);
                         }
-                        ProgressMessage::Download(bytes) => {
+                        download::ProgressMessage::Download(bytes) => {
                             p_dl.inc(bytes);
                         }
-                        ProgressMessage::PostProcess(bytes) => {
+                        download::ProgressMessage::PostProcess(bytes) => {
                             p_pp.inc(bytes);
                         }
                     }
@@ -381,6 +384,8 @@ async fn verify_subcommand(cli: &VerifyCli, bars: MultiProgress) -> Result<()> {
 
     loop {
         tokio::select! {
+            biased;
+
             c = ctrl_c() => {
                 let _ = bars.clear();
                 c?;
@@ -395,12 +400,10 @@ async fn verify_subcommand(cli: &VerifyCli, bars: MultiProgress) -> Result<()> {
             p = p_rx.recv() => {
                 if let Some(msg) = p {
                     match msg {
-                        ProgressMessage::TotalDownload(_) => {}
-                        ProgressMessage::TotalPostProcess(bytes) => {
+                        verify::ProgressMessage::Total(bytes) => {
                             p_verify.set_length(bytes);
                         }
-                        ProgressMessage::Download(_) => {}
-                        ProgressMessage::PostProcess(bytes) => {
+                        verify::ProgressMessage::Progress(bytes) => {
                             p_verify.inc(bytes);
                         }
                     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -10,6 +10,7 @@ use std::{
 
 use anstyle_progress::TermProgress;
 use indicatif::{BinaryBytes, MultiProgress, ProgressBar, ProgressState, style::ProgressTracker};
+use tokio::sync::mpsc::{self, error::SendError};
 use tracing_subscriber::fmt::MakeWriter;
 
 /// Type that receives progress values and buffers them to compute the average
@@ -194,4 +195,85 @@ pub fn progress_percentage(bars: &[&ProgressBar]) -> u8 {
         .sum::<f64>();
 
     (ratio_sum / bars.len() as f64 * 100f64).round() as u8
+}
+
+pub const THROTTLE_DELAY: Duration = Duration::from_millis(50);
+
+pub struct ThrottledProgress<T> {
+    progress_tx: mpsc::Sender<T>,
+    transform: fn(u64) -> T,
+    delay: Duration,
+    last_send: Instant,
+    pending: u64,
+}
+
+impl<T> ThrottledProgress<T> {
+    pub fn new(progress_tx: mpsc::Sender<T>, transform: fn(u64) -> T, delay: Duration) -> Self {
+        let now = Instant::now();
+
+        Self {
+            progress_tx,
+            transform,
+            delay,
+            last_send: now.checked_sub(delay).unwrap_or(now),
+            pending: 0,
+        }
+    }
+
+    async fn force_update(&mut self, inc: u64) -> Result<(), SendError<T>> {
+        self.progress_tx
+            .send((self.transform)(self.pending + inc))
+            .await?;
+
+        self.pending = 0;
+        self.last_send = Instant::now();
+
+        Ok(())
+    }
+
+    fn force_update_blocking(&mut self, inc: u64) -> Result<(), SendError<T>> {
+        self.progress_tx
+            .blocking_send((self.transform)(self.pending + inc))?;
+
+        self.pending = 0;
+        self.last_send = Instant::now();
+
+        Ok(())
+    }
+
+    pub async fn update(&mut self, inc: u64) -> Result<(), SendError<T>> {
+        if self.last_send.elapsed() >= self.delay {
+            self.force_update(inc).await?;
+        } else {
+            self.pending += inc;
+        }
+
+        Ok(())
+    }
+
+    pub fn update_blocking(&mut self, inc: u64) -> Result<(), SendError<T>> {
+        if self.last_send.elapsed() >= self.delay {
+            self.force_update_blocking(inc)?;
+        } else {
+            self.pending += inc;
+        }
+
+        Ok(())
+    }
+
+    pub async fn flush(&mut self) -> Result<(), SendError<T>> {
+        if self.pending > 0 {
+            self.force_update(0).await?;
+        }
+
+        Ok(())
+    }
+
+    pub fn flush_blocking(&mut self) -> Result<(), SendError<T>> {
+        if self.pending > 0 {
+            self.force_update_blocking(0)?;
+        }
+
+        Ok(())
+    }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -17,7 +17,8 @@ use tokio::{
 use tracing::{debug, error};
 
 use crate::{
-    download::{CancelOnDrop, ProgressMessage, check_cancel},
+    cancel::{CancelOnDrop, check_cancel},
+    progress::{THROTTLE_DELAY, ThrottledProgress},
     version::{self, VersionEntry, VersionInfo},
 };
 
@@ -56,6 +57,11 @@ pub enum Error {
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub enum ProgressMessage {
+    Total(u64),
+    Progress(u64),
+}
 
 pub struct Verifier {
     directory: Arc<Dir>,
@@ -133,6 +139,9 @@ impl Verifier {
         let mut hasher = Hasher::new();
         let mut buf = [0u8; 8192];
 
+        let mut progress =
+            ThrottledProgress::new(progress_tx, ProgressMessage::Progress, THROTTLE_DELAY);
+
         loop {
             check_cancel(cancel_signal).map_err(Error::Cancelled)?;
 
@@ -145,10 +154,12 @@ impl Verifier {
 
             hasher.update(&buf[..n]);
 
-            progress_tx
-                .blocking_send(ProgressMessage::PostProcess(n as u64))
+            progress
+                .update_blocking(n as u64)
                 .map_err(Error::Progress)?;
         }
+
+        progress.flush_blocking().map_err(Error::Progress)?;
 
         let digest = hasher.finalize();
         if digest != entry.crc32 {
@@ -197,11 +208,11 @@ impl Verifier {
 
         // Report initial progress.
         self.progress_tx
-            .send(ProgressMessage::TotalPostProcess(total_size))
+            .send(ProgressMessage::Total(total_size))
             .await
             .map_err(Error::Progress)?;
         self.progress_tx
-            .send(ProgressMessage::PostProcess(0))
+            .send(ProgressMessage::Progress(0))
             .await
             .map_err(Error::Progress)?;
 


### PR DESCRIPTION
Previously, progress updates were sent so frequently that it overwhelmed `tokio::select!()` and made it difficult to respond to `SIGINT`. Pressing Ctrl+C could require many tries, especially when running `nudl verify`.

Progress updates are now throttled to once per 50ms per task. The `tokio::select!()` futures are now also polled in order with `ctrl_c()` being first.